### PR TITLE
Added ability to set local layout to null

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -288,7 +288,7 @@ Renderer.prototype.render = function *(template, locals, options) {
   debug("rendering %s template", chalk.underline(template));
 
   // extract layout id
-  var layoutId = locals.layout === undefined ? o.defaultLayout : locals.layout;
+  var layoutId = typeof locals.layout === 'undefined' ? o.defaultLayout : locals.layout;
   delete locals.layout;
 
   // extract pre-rendered body

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -288,7 +288,7 @@ Renderer.prototype.render = function *(template, locals, options) {
   debug("rendering %s template", chalk.underline(template));
 
   // extract layout id
-  var layoutId = locals.layout || o.defaultLayout;
+  var layoutId = locals.layout === undefined ? o.defaultLayout : locals.layout;
   delete locals.layout;
 
   // extract pre-rendered body

--- a/test/renderer.js
+++ b/test/renderer.js
@@ -338,6 +338,18 @@ describe("Renderer#render(template, locals, options)", function () {
     assert.equal(result.trim(), "Layout: Hello, World!");
   });
 
+  it("should allow overwriting options.defaultView with null (no layout)", function *() {
+    var r = new Renderer({
+      root: fixture(),
+      defaultLayout: "does-not-exist"
+    });
+    var result = yield r.render("simple", {
+      layout: null,
+      name: "World"
+    });
+    assert.equal(result.trim(), "Hello, World!");
+  });
+
   it("should add some meta locals (and remove 'layout' from locals)", function *() {
     var r = new Renderer({ root: fixture() });
     var result = yield r.render("meta", { layout: "empty" });


### PR DESCRIPTION
Currently, when `defaultLayout` is set, setting `layout` to `null` locally does not result in a view rendering without a layout, which is a desirable feature.

All tests passing; no new tests added.