### PR TITLE
Koa v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,21 @@ and writes the generated view as the response. There is also
 `renderView(view, locals)`, which yields the raw string. This allows you to
 modify the response further.
 
+`koa-handlebars` v2 works with the Koa v2 async/await signature.
+
 **app.js**
 ```js
-var koa = require("koa");
+var Koa = require("koa");
 var handlebars = require("koa-handlebars");
 
-var app = koa();
+var app = new Koa();
 
 app.use(handlebars({
   defaultLayout: "main"
 }));
 
-app.use(function *() {
-  yield this.render("index", {
+app.use(async function() {
+  await this.render("index", {
     title: "Test Page",
     name: "World"
   });

--- a/example/advanced/app.js
+++ b/example/advanced/app.js
@@ -5,7 +5,7 @@ var handlebars = require("../../index.js");
 var path = require("path");
 
 // locals
-var app = koa();
+var app = new Koa();
 
 // middleware
 app.use(require("koa-favi")());
@@ -44,8 +44,8 @@ app.use(handlebars({
 }));
 
 // render example
-app.use(function *() {
-  yield this.render("test", {
+app.use(async function() {
+  await this.render("test", {
     user: { name: "World" }
   });
 });

--- a/example/simple/app.js
+++ b/example/simple/app.js
@@ -1,7 +1,7 @@
-var koa = require("koa");
+var Koa = require("koa");
 var handlebars = require("../../index.js");
 
-var app = koa();
+var app = new Koa();
 
 app.use(require("koa-favi")());
 app.use(require("koa-logger")());
@@ -11,8 +11,8 @@ app.use(handlebars({
   defaultLayout: "main"
 }));
 
-app.use(function *() {
-  yield this.render("test", {
+app.use(async function() {
+  await this.render("test", {
     user: { name: "World" }
   });
 });

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -4,14 +4,14 @@ var chalk = require("chalk");
 var debug = require("debug")("koa-handlebars");
 var extend = require("extend");
 var fm = require("front-matter");
-var fs = require("co-fs");
+var fs = require("mz/fs");
 var handlebars = require("handlebars");
 var path = require("path");
-var thunkify = require("thunkify");
+var promisify = require("es6-promisify");
 
 // helpers
-var find = thunkify(require("find-alternate-file"));
-var readdir = thunkify(require("recursive-readdir"));
+var find = promisify(require("find-alternate-file"));
+var readdir = promisify(require("recursive-readdir"));
 
 // single export
 module.exports = Renderer;
@@ -66,9 +66,9 @@ Renderer.defaults = require("./defaults.js");
  * @param {String} file  An absolute file path to a template file
  * @returns {String}
  */
-Renderer.prototype.getFile = function *(file) {
+Renderer.prototype.getFile = async function(file) {
   debug("reading file %s", chalk.grey(path.relative(this.options.root, file)));
-  return fm(yield fs.readFile(file, "utf8"));
+  return fm(await fs.readFile(file, "utf8"));
 };
 
 /**
@@ -77,8 +77,8 @@ Renderer.prototype.getFile = function *(file) {
  * @param {String} file  An absolute path to a template file
  * @returns {Function}
  */
-Renderer.prototype.compileTemplate = function *(file) {
-  var meta = yield this.getFile(file);
+Renderer.prototype.compileTemplate = async function(file) {
+  var meta = await this.getFile(file);
   debug("compiling template %s", chalk.grey(path.relative(this.options.root, file)));
   meta.fn = this.handlebars.compile(meta.body);
   meta.render = function (locals, options) {
@@ -93,9 +93,9 @@ Renderer.prototype.compileTemplate = function *(file) {
  * @param {String} file  An absolute path to a template file
  * @returns {Function}
  */
-Renderer.prototype.getTemplate = function *(file) {
+Renderer.prototype.getTemplate = async function(file) {
   var o = this.options;
-  var abs = yield find(file, o.extension);
+  var abs = await find(file, o.extension);
   if (!abs) throw new Error("Could not find template file: " + file);
 
   var rel = path.relative(o.root, abs);
@@ -107,13 +107,13 @@ Renderer.prototype.getTemplate = function *(file) {
       debug("template %s found in cache", chalk.grey(rel));
       return this.cache.get(key);
     } else {
-      var template = yield this.compileTemplate(abs);
+      var template = await this.compileTemplate(abs);
       debug("saving template %s to cache", chalk.grey(rel));
       this.cache.set(key, template); // save to the cache
       return template;
     }
   } else {
-    return yield this.compileTemplate(abs);
+    return await this.compileTemplate(abs);
   }
 };
 
@@ -142,8 +142,8 @@ Renderer.prototype.viewPath = function (id) {
  * @param {String} id
  * @returns {Function}
  */
-Renderer.prototype.getView = function *(id) {
-  return yield this.getTemplate(this.viewPath(id));
+Renderer.prototype.getView = async function(id) {
+  return await this.getTemplate(this.viewPath(id));
 };
 
 /**
@@ -169,9 +169,9 @@ Renderer.prototype.layoutPath = function (id) {
  * @param {String} id
  * @returns {Function}
  */
-Renderer.prototype.getLayout = function *(id) {
+Renderer.prototype.getLayout = async function(id) {
   if (!id) return false;
-  return yield this.getTemplate(this.layoutPath(id));
+  return await this.getTemplate(this.layoutPath(id));
 };
 
 /**
@@ -193,18 +193,18 @@ Renderer.prototype.partialId = function (file) {
  *
  * @returns {Array:String}  List of partial template filenames in all dirs
  */
-Renderer.prototype.findPartials = function *() {
+Renderer.prototype.findPartials = async function() {
   var o = this.options;
   var dir = path.resolve(o.root, o.partialsDir);
   var extensions = normalizeExtensions(o.extension);
   var key = "partials:list:" + dir;
   debug("searching for partials in %s", chalk.grey(dir));
 
-  var exists = yield fs.exists(dir);
+  var exists = await fs.exists(dir);
   if (!exists) return [];
 
   if (o.cache && this.cache.peek(key)) return this.cache.get(key);
-  var files = yield readdir(dir);
+  var files = await readdir(dir);
 
   files = files.map(function (file) {
     return path.relative(dir, file);
@@ -226,9 +226,9 @@ Renderer.prototype.findPartials = function *() {
  * @param {String} file
  * @returns {Function}
  */
-Renderer.prototype.getPartial = function *(file) {
+Renderer.prototype.getPartial = async function(file) {
   var o = this.options;
-  var tpl = yield this.getTemplate(path.resolve(o.root, o.partialsDir, file));
+  var tpl = await this.getTemplate(path.resolve(o.root, o.partialsDir, file));
   return tpl.fn;
 };
 
@@ -237,14 +237,12 @@ Renderer.prototype.getPartial = function *(file) {
  *
  * @returns {Object}  Shallow hash of all partials
  */
-Renderer.prototype.getPartials = function *() {
+Renderer.prototype.getPartials = async function() {
   var self = this;
-  var files = yield this.findPartials();
-
-  return yield files.reduce(function (acc, file) {
-    acc[self.partialId(file)] = self.getPartial(file);
-    return acc;
-  }, {});
+  var files = await this.findPartials();
+  var partials = {};
+  for (file of files) partials[self.partialId(file)] = await self.getPartial(file);
+  return partials;
 };
 
 /**
@@ -283,7 +281,7 @@ Renderer.prototype.helper = function (name, fn) {
  * @param {Object} [locals]   The template params
  * @param {Object} [options]  Additional options for handlebars
  */
-Renderer.prototype.render = function *(template, locals, options) {
+Renderer.prototype.render = async function(template, locals, options) {
   var o = this.options;
 
   locals = extend(true, {}, locals);
@@ -298,10 +296,10 @@ Renderer.prototype.render = function *(template, locals, options) {
   var body = options.body;
 
   // retrieve layout (if needed)
-  var layout = yield this.getLayout(layoutId);
+  var layout = await this.getLayout(layoutId);
 
   // retrieve view
-  if (!body) var view = yield this.getView(template);
+  if (!body) var view = await this.getView(template);
 
   // extend locals with front-matter data
   if (layout && layout.attributes) extend(locals, layout.attributes);
@@ -312,7 +310,7 @@ Renderer.prototype.render = function *(template, locals, options) {
   if (layoutId) options.data.layout = layoutId;
 
   // load partials
-  options.partials = yield this.getPartials();
+  options.partials = await this.getPartials();
 
   // when a layout is needed
   if (layout) {
@@ -330,34 +328,34 @@ Renderer.prototype.render = function *(template, locals, options) {
  *
  * @return {GeneratorFunction}
  */
-Renderer.prototype.middleware = function () {
+Renderer.prototype.middleware = function() {
   var self = this;
 
-  return function *(next) {
+  return async function(ctx, next) {
     // renders the template and returns the string
     // this allows you to do further processing on the response (like using
     // another type besides HTML)
     // this also merges in ctx.state and ctx.locals (if available)
-    this.renderView = function *(view, locals, options) {
-      var l = extend(true, {}, this.state, this.locals, locals);
+    ctx.renderView = async function(view, locals, options) {
+      var l = extend(true, {}, ctx.state, ctx.locals, locals);
       var o = extend(true, { data: {} }, options);
-      o.data.koa = this;
+      o.data.koa = ctx;
 
       try {
-        return yield self.render(view, l, o);
+        return await self.render(view, l, o);
       } catch (err) {
         debug("unable to render view %s", chalk.underline(view), err.stack);
-        this.throw(500, "unable to render view: " + view + " because " + err.message);
+        ctx.throw(500, "unable to render view: " + view + " because " + err.message);
       }
     };
 
     // renders the template and automatically responds
-    this.render = function *(view, locals, options) {
-      this.type = "html";
-      this.body = yield this.renderView(view, locals, options);
+    ctx.render = async function(view, locals, options) {
+      ctx.type = "html";
+      ctx.body = await ctx.renderView(view, locals, options);
     };
 
-    yield next;
+    await next();
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,38 +1,35 @@
 {
   "name": "koa-handlebars",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:dominicbarnes/koa-handlebars.git"
   },
   "dependencies": {
-    "chalk": "^0.5.1",
-    "co-fs": "^1.2.0",
-    "debug": "^2.0.0",
-    "extend": "^1.3.0",
-    "find-alternate-file": "^1.0.4",
-    "front-matter": "^0.2.0",
-    "handlebars": "^4.0.5",
-    "lru-cache": "^2.5.0",
+    "chalk": "^1.1.3",
+    "debug": "^2.3.2",
+    "es6-promisify": "^5.0.0",
+    "extend": "^3.0.0",
+    "find-alternate-file": "^1.0.5",
+    "front-matter": "^2.1.0",
+    "handlebars": "^4.0.6",
+    "lru-cache": "^4.0.1",
+    "mz": "^2.5.0",
     "recursive-readdir": "^2.1.0",
-    "strip-extension": "^1.0.1",
-    "thunkify": "^2.1.2",
-    "to-camel-case": "^0.2.1"
+    "strip-extension": "^1.1.0",
+    "to-camel-case": "^1.0.0"
   },
   "devDependencies": {
-    "co": "^3.1.0",
-    "co-mocha": "^1.0.1",
-    "is-generator": "^1.0.0",
-    "istanbul-harmony": "^0.3.0",
-    "koa": "^0.11.0",
+    "istanbul-harmony": "^0.3.16",
+    "koa": "^2.0.0",
     "koa-favi": "^0.1.0",
-    "koa-logger": "^1.2.2",
-    "mocha": "^1.21.4",
-    "nop": "0.0.0",
-    "opener": "^1.4.0"
+    "koa-logger": "^1.3.0",
+    "mocha": "^3.1.2",
+    "nop": "1.0.0",
+    "opener": "^1.4.2"
   },
   "scripts": {
-    "test": "node node_modules/.bin/istanbul test node_modules/.bin/_mocha",
+    "test": "node --harmony node_modules/.bin/istanbul test node_modules/.bin/_mocha",
     "coverage": "npm test && opener coverage/lcov-report/index.html"
   }
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,0 @@
---require co-mocha


### PR DESCRIPTION
Migrates to Koa v2 signature:

- async functions in place of generator functions, await in place of yield
- middleware takes ctx in place of this
- middleware chaining is via await next() in place of yield next

Committed on koa-v2 branch.

Addresses #25 

This should be published @next until Koa v2 is published @latest.