### PR TITLE
Delete cached template when compiling template

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -78,6 +78,7 @@ Renderer.prototype.getFile = async function(file) {
  * @returns {Function}
  */
 Renderer.prototype.compileTemplate = async function(file) {
+  if (this.options.cache) this.cache.del("template:"+file)
   var meta = await this.getFile(file);
   debug("compiling template %s", chalk.grey(path.relative(this.options.root, file)));
   meta.fn = this.handlebars.compile(meta.body);


### PR DESCRIPTION
I had a requirement to re-compile previously compiled templates, but the `compileTemplate()` function left the previous version in the cache; this PR deletes any previously cached version when compiling a template.

Perhaps you could also now promote the 2.0.0 branch to @latest in npm?